### PR TITLE
rm spool_fetch_msg

### DIFF
--- a/src/store/spool.c
+++ b/src/store/spool.c
@@ -388,7 +388,7 @@ static ngx_int_t spool_fetch_msg_callback(ngx_int_t code, nchan_msg_t *msg, fetc
         if(spool->reserved == 0) {
           destroy_spool(spool);
         }
-        spool_fetch_msg(nuspool);
+        // spool_fetch_msg(nuspool);
       }
       else if(spool->id.tagcount == 1 && nchan_compare_msgids(&spool->id, &oldest_msg_id) == 0) {
         // oldest msgid not found or expired. that means there are no messages in this channel, 


### PR DESCRIPTION
https://github.com/slact/nchan/issues/534

Removes spool fetch message. When using Redis, a channel can stop receiving new messages if they are published faster than they can be sent to subscribers and the message buffer is sufficiently small.

Should resolve these errors in the logs:
`nginx: worker process: /tmp/nchan-1.2.8.1/src/store/spool.c:479: spool_fetch_msg: Assertion 'spool->msg_status == MSG_INVALID' failed.`
